### PR TITLE
Add Google tag, which should set up Google Analytics

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -37,7 +37,7 @@ summaryLength = 30
 # I can't find documentation for these next three
 buildDrafts = false
 buildFuture = false
-# googleAnalytics = "G-XXXXXXXXX"
+googleAnalytics = "G-GH875KB7P0"
 
 # Refer to the Hugo docs for permalink configuration.
 # permalinks = ?


### PR DESCRIPTION
I'm not sure why I'm doing this via a PR, but the Add-Google-Analytics branch introduces what should be the necessary changes to get G. A. running. According to the [blowfish documentation](https://nunocoracao.github.io/blowfish/docs/partials/#google-analytics), this should be all I need to do. We will go ahead and merge this, then merge `gh-pages` <- `dev`, and see if it works.